### PR TITLE
renamed the editor umd entry & ImagePlugin: align menu icons are not aligned

### DIFF
--- a/packages/access-react/src/reacts/image/view/style.css
+++ b/packages/access-react/src/reacts/image/view/style.css
@@ -20,6 +20,7 @@
   left: 50%;
   transform: translateX(-50%);
   height: 28px;
+  line-height: 20px;
   background: #fff;
   white-space: nowrap;
   border-radius: 2px;

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -2,7 +2,7 @@
   "name": "@syllepsis/editor",
   "version": "0.0.2-alpha.0",
   "description": "middle layer of syllepsis editor",
-  "umd": "dist/umd/index.umd.js",
+  "umd": "dist/umd/index.js",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",
   "typings": "dist/es/index.d.ts",


### PR DESCRIPTION
fix(access-react): ImagePlugin: align menu icons are not aligned
build(editor): renamed the umd entry