### PR TITLE
fix: treat `paragraph` as a not defining `node`

### DIFF
--- a/packages/adapter/src/schema/basics.ts
+++ b/packages/adapter/src/schema/basics.ts
@@ -22,6 +22,7 @@ class Doc extends SylSchema<never> {
 
 class Paragraph extends Block<IParagraphAttrs> {
   public name = 'paragraph';
+  public defining = false;
 
   public defaultFontSize = 16;
   public canMatch = (dom: HTMLParagraphElement) => true;


### PR DESCRIPTION
fix #86