### PR TITLE
fix(ImagePlugin): Error when parsing `<img>` without `align` attribute

### DIFF
--- a/packages/plugin-basic/src/atom/image/index.ts
+++ b/packages/plugin-basic/src/atom/image/index.ts
@@ -341,7 +341,7 @@ class Image extends BlockAtom<ImageAttrs> {
           src: dom.getAttribute('src') || '',
           alt: dom.getAttribute('alt') || '',
           name: dom.getAttribute('name') || '',
-          align: (dom.getAttribute('align') || this.attrs.align.default) as any,
+          align: (dom.getAttribute('align') || undefined) as any,
           width,
           height,
         };


### PR DESCRIPTION
fix #120