### PR TITLE
fix(CodeBlockPlugin): Erroneously deleted empty `code_block` when pre…

### DIFF
--- a/packages/plugin-code-block/src/code-block/controller.ts
+++ b/packages/plugin-code-block/src/code-block/controller.ts
@@ -122,6 +122,18 @@ class CodeBlockController extends SylController<ICodeBlockProps> {
     },
   };
 
+  public keymap = {
+    Backspace: (editor: SylApi, state: SylApi['view']['state'], dispatch: SylApi['view']['dispatch']) => {
+      const { $from, empty } = state.selection;
+      if (!empty || $from.nodeBefore) return false;
+      const beforePos = $from.before();
+      const prevNode = state.doc.resolve(beforePos).nodeBefore;
+      if (!prevNode || prevNode.type.name !== PLUGIN_NAME || prevNode.childCount) return false;
+      dispatch(state.tr.join(beforePos));
+      return true;
+    },
+  };
+
   constructor(editor: SylApi, props: ICodeBlockProps) {
     super(editor, props);
     setConfig(props);


### PR DESCRIPTION
…ssing `Backspace` after

fix #130