### PR TITLE
fix(SylApi): `replace` ignores marks configuration when `inheritMarks…

### DIFF
--- a/packages/adapter/src/command/state.ts
+++ b/packages/adapter/src/command/state.ts
@@ -252,7 +252,13 @@ const replace = (view: EditorView, nodeInfo: INodeInfo | string, replaceOption?:
   if (length >= 0) {
     $to = state.doc.resolve(config.index + length);
   }
-  if (config.inheritMarks) newNode.marks = $from.marksAcross($to) || [];
+  if (config.inheritMarks) {
+    ($from.marksAcross($to) || []).forEach(mark => {
+      if (!newNode.marks.some(({ type }) => type === mark.type)) {
+        newNode.marks = mark.addToSet(newNode.marks);
+      }
+    });
+  }
 
   const { index, scrollIntoView, focus, addToHistory } = config;
   if (length < 0) length = $to.pos - $from.pos;

--- a/packages/plugin-basic/src/atom/image/index.ts
+++ b/packages/plugin-basic/src/atom/image/index.ts
@@ -283,7 +283,7 @@ class ImageController extends SylController<ImageProps> {
       const html = event.clipboardData.getData('text/html');
       const text = event.clipboardData.getData('text/plain');
       // if clipBoard get files and without any text and the src of img is a blob, then treat it as file
-      if (!files.length || text || html.match(/<img/g)?.length !== 1 || !/<img[^>]*src=['"]blob:[^>]*>/.test(html)) {
+      if (!files.length || text || html.match(/<img/g)?.length !== 1 || !/<img[^>]*\s+src=['"]blob:[^>]*>/.test(html)) {
         return false;
       }
       editor.command.image!.insertImages(files);

--- a/test/case/adapter/sylApi.test.ts
+++ b/test/case/adapter/sylApi.test.ts
@@ -831,6 +831,33 @@ describe('replace API test', () => {
     expect(html).toEqual('<h1>replace</h1>');
   });
 
+  test('can replace text', async () => {
+    const { html, isBold } = await page.evaluate(() => {
+      editor.setHTML('<p>123</p>');
+      editor.replace(
+        {
+          type: 'text',
+          content: 'replace',
+          marks: [
+            {
+              type: 'bold',
+            },
+          ],
+        },
+        {
+          index: 1,
+          length: 3,
+          scrollIntoView: false,
+          focus: false,
+        },
+      );
+      editor.setSelection({ index: 2, length: 0 });
+      return { html: editor.getHTML(), isBold: editor.isActive('bold') };
+    });
+    expect(html).toEqual('<p><strong>replace</strong></p>');
+    expect(isBold).toBe(true);
+  });
+
   test('replace support addToHistory config', async () => {
     const html = await page.evaluate(() => {
       editor.setHTML('<p>123</p>');


### PR DESCRIPTION
…` is true

fix #176