### PR TITLE
fix: Decoration plugin appendTransaction throw RangeError when resolve

### DIFF
--- a/packages/adapter/src/basic/decoration/index.ts
+++ b/packages/adapter/src/basic/decoration/index.ts
@@ -102,7 +102,7 @@ const DecorationPlugin = () =>
       if (newDecorations.length < oldDecorations.length) {
         oldDecorations.some(decoration => {
           if (
-            decoration.from < tr.doc.nodeSize &&
+            decoration.from <= tr.doc.content.size &&
             newDecorations.every(({ spec }) => spec.key !== decoration.spec.key)
           ) {
             const $pos = tr.doc.resolve(decoration.from);


### PR DESCRIPTION
`decoration.from` should not be greater than `tr.doc.content.size`, which is `tr.doc.nodeSize - 2`.
Otherwise, `tr.doc.resolve(decoration.from)` will throw RangeError.

This fixes #226 ,where `decoration.from` is 3 and `tr.doc.nodeSize` is 4 after deleting all content.